### PR TITLE
add expires docs to set_cookie.

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -542,6 +542,10 @@ class RequestHandler(object):
 
         Newly-set cookies are not immediately visible via `get_cookie`;
         they are not present until the next request.
+        
+        expires may be a numeric timestamp as returned by `time.time`,
+        a time tuple as returned by `time.gmtime`, or a 
+        `datetime.datetime` object.
 
         Additional keyword arguments are set on the cookies.Morsel
         directly.


### PR DESCRIPTION
update set_cookie docstring to explain what expires will accept and behave properly, without having to go track down httputil.format_timestamp, which is not exposed in the docs(that I could find).